### PR TITLE
Fix how course conflicts are returned

### DIFF
--- a/backend/core/api_endpoints/user_views.py
+++ b/backend/core/api_endpoints/user_views.py
@@ -138,13 +138,11 @@ def add_course_to_schedule(request):
 
     if new_lecture_section:
 
-        lecture_conflicts = check_time_conflicts(new_lecture_section, user_courses)
-        if lecture_conflicts:
-            conflict_sections = LectureSection.objects.filter(id__in=lecture_conflicts)
-
+        conflicts = check_time_conflicts(new_lecture_section, user_courses)
+        if conflicts:
             return Response({
                 "error": "Time conflicts detected",
-                "conflicts": LectureSectionSerializer(conflict_sections, many=True).data
+                "conflicts": conflicts
             }, status=status.HTTP_409_CONFLICT)
 
         user.lecture_sections.add(new_lecture_section)
@@ -158,13 +156,12 @@ def add_course_to_schedule(request):
 
         if new_non_lecture_section:
 
-            non_lecture_conflicts = check_time_conflicts(new_non_lecture_section, user_courses)
-            if non_lecture_conflicts:
-                conflict_sections = NonLectureSection.objects.filter(id__in=non_lecture_conflicts)
+            conflicts = check_time_conflicts(new_lecture_section, user_courses)
+            if conflicts:
 
                 return Response({
                     "error": "Time conflicts detected",
-                    "conflicts": NonLectureSectionSerializer(conflict_sections, many=True).data,
+                    "conflicts": conflicts,
                 }, status=status.HTTP_409_CONFLICT)
 
             user.non_lecture_sections.add(new_non_lecture_section)

--- a/backend/core/utils.py
+++ b/backend/core/utils.py
@@ -3,6 +3,8 @@ from datetime import datetime
 
 from datetime import date
 
+from django.forms import model_to_dict
+
 # Get today's date
 DATE = date.today()
 
@@ -110,7 +112,6 @@ def check_time_conflicts(new_course, user_courses):
             for course in day_to_event_map.get(day, []):
 
                 if check_course_conflicts(block, course["time_block"]):
+                    conflicts.add(course["section"])
 
-                    conflicts.add(course["section"].id)
-
-    return list(conflicts)
+    return list([model_to_dict(course) for course in conflicts])


### PR DESCRIPTION
Change `check_time_conflicts()` in `core/utils.py` to return the courses that conflict as dictionaries , instead of using serializers