### PR TITLE
Remove dialog appearing for individual course removals & add back margin

### DIFF
--- a/frontend/src/schedule-builder/scheduleBuilder.js
+++ b/frontend/src/schedule-builder/scheduleBuilder.js
@@ -551,7 +551,7 @@ export function ScheduleBuilder() {
         </Card>
 
         <div className="d-flex align-items-center gap-3 mb-3">
-          <h4 className="fw-bold mb-0">Your Current Schedule</h4>
+          <h4 className="fw-bold mb-0 ms-2">Your Current Schedule</h4>
           <div className="d-flex gap-2 flex-grow-1">
             <Button 
               variant={viewMode === "list" ? "primary" : "outline-primary"} 
@@ -578,7 +578,7 @@ export function ScheduleBuilder() {
               variant="outline-danger"
               size="md"
               style={{ width: 'max-content' }}
-              className="d-flex align-items-center gap-2 ms-auto"
+              className="d-flex align-items-center gap-2 ms-auto me-2"
               >
               <BsTrash /> Clear Schedule
               </Button>


### PR DESCRIPTION
* Removed the dialog from appearing for each individual course removal from a user's schedule, keeping it for clearing a whole schedule
* Add back margin for the current schedule row